### PR TITLE
Fixed several breaking bugs. Added ability for user to set fields to display and now defaults to all fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ class Person(models.Model):
         inline_type = 'tabular'
         inline_reverse = ['business_addr',
                           ('home_addr', {'fields': ['street', 'city', 'state', 'zip']}),
-                          ('other_addr', {'form': OtherForm, 'exclude': ()})
                           ]
     admin.site.register(Person, PersonAdmin)
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Work "shamelessly copied from":
 * [adminreverse](https://github.com/rpkilby/django-reverse-admin)
 * [reverseadmin](http://djangosnippets.org/snippets/2032/)
 
-Made to work with django 1.9.6
+Made to work with django 1.10
 
 ## Example
 
@@ -56,6 +56,6 @@ class Person(models.Model):
 inline_type can be either "tabular" or "stacked" for tabular and
 stacked inlines respectively.
 
-The module is designed to work with Django 1.9.6. Since it hooks into
+The module is designed to work with Django 1.10. Since it hooks into
 the internals of the admin package, it may not work with later Django
 versions.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ class Person(models.Model):
     from django.contrib import admin
     from django.db import models
     from models import Person
-    from reverseadmin import ReverseModelAdmin
+    from django_reverse_admin import ReverseModelAdmin
     class AddressForm(models.Form):
         pass
     class PersonAdmin(ReverseModelAdmin):

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ entity, django admins standard inline classes can't be used. Which is
 why I created this module that implements "reverse inlines" for this
 use case.
 
-Work "shamelessly copied from":
+Fix/extension of:
 * [adminreverse](https://github.com/rpkilby/django-reverse-admin)
 * [reverseadmin](http://djangosnippets.org/snippets/2032/)
 
@@ -46,10 +46,10 @@ class Person(models.Model):
         pass
     class PersonAdmin(ReverseModelAdmin):
         inline_type = 'tabular'
-        inline_reverse = ('business_addr', ('home_addr', AddressForm), ('other_addr' (
-            'form': OtherForm
-            'exclude': ()
-        )))
+        inline_reverse = ['business_addr',
+                          ('home_addr', {'fields': ['street', 'city', 'state', 'zip']}),
+                          ('other_addr', {'form': OtherForm, 'exclude': ()})
+                          ]
     admin.site.register(Person, PersonAdmin)
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ class Person(models.Model):
     from django.db import models
     from models import Person
     from django_reverse_admin import ReverseModelAdmin
-    class AddressForm(models.Form):
-        pass
+
+
     class PersonAdmin(ReverseModelAdmin):
         inline_type = 'tabular'
         inline_reverse = ['business_addr',

--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -7,7 +7,7 @@ from django.db.models import OneToOneField, ForeignKey
 from django.forms import ModelForm
 from django.forms.formsets import all_valid
 from django.forms.models import BaseModelFormSet, modelformset_factory
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
 from django.utils.functional import curry
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -233,7 +233,7 @@ class ReverseModelAdmin(ModelAdmin):
             media = media + inline_admin_formset.media
 
         context = {
-            'title': _('Add %s') % force_unicode(opts.verbose_name),
+            'title': _('Add %s') % force_text(opts.verbose_name),
             'adminform': adminForm,
             #'is_popup': request.REQUEST.has_key('_popup'),
             'is_popup': False,

--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -4,7 +4,7 @@ from django.contrib.admin.options import InlineModelAdmin
 from django.contrib.admin.utils import flatten_fieldsets
 from django.db import models
 from django.db.models import OneToOneField, ForeignKey
-from django.forms import ModelForm, ALL_FIELDS
+from django.forms import ModelForm
 from django.forms.formsets import all_valid
 from django.forms.models import BaseModelFormSet, modelformset_factory
 from django.utils.encoding import force_unicode

--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -184,7 +184,7 @@ class ReverseModelAdmin(ModelAdmin):
                     prefix = "%s-%s" % (prefix, prefixes[prefix])
                 formset = FormSet(data=request.POST, files=request.FILES,
                                   instance=new_object,
-                                  save_as_new=request.POST.has_key("_saveasnew"),
+                                  save_as_new="_saveasnew" in request.POST,
                                   prefix=prefix)
                 formsets.append(formset)
             if all_valid(formsets) and form_validated:
@@ -235,7 +235,7 @@ class ReverseModelAdmin(ModelAdmin):
         context = {
             'title': _('Add %s') % force_text(opts.verbose_name),
             'adminform': adminForm,
-            #'is_popup': request.REQUEST.has_key('_popup'),
+            #'is_popup': '_popup' in request.REQUEST,
             'is_popup': False,
             'show_delete': False,
             'media': mark_safe(media),

--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -111,11 +111,11 @@ class ReverseInlineModelAdmin(InlineModelAdmin):
             "exclude": exclude,
             "formfield_callback": curry(self.formfield_for_dbfield, request=request),
         }
-        defaults.update(kwargs)
+        kwargs.update(defaults)
         return reverse_inlineformset_factory(self.parent_model,
                                              self.model,
                                              self.parent_fk_name,
-                                             **defaults)
+                                             **kwargs)
 
 class ReverseModelAdmin(ModelAdmin):
     '''


### PR DESCRIPTION
Updated README examples and wording to match. 
One downgrade: formerly, reverse_inline = [('address', AddressForm)] would be accepted. This is not supported. You must put all extra arguments in a dictionary:
reverse_inline = [('address', {'form':AddressForm})]
The old code would treat any second argument in a tuple as a Form - now it treats any second argument in a tuple as a kwargs dictionary, in order to be able to handle multiple arguments.
