### PR TITLE
Use .none() to create empty querysets

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -32,7 +32,7 @@ class ReverseInlineFormSet(BaseModelFormSet):
         if object:
             qs = self.model.objects.filter(pk=object.id)
         else:
-            qs = self.model.objects.filter(pk=-1)
+            qs = self.model.objects.none()
             self.extra = 1
         super(ReverseInlineFormSet, self).__init__(data, files,
                                                    prefix=prefix,


### PR DESCRIPTION
When using UUID based primary key `self.model.objects.filter(pk=-1)` will raise: 
`ValidationError: ["'-1' is not a valid UUID."]`

This little pr fixes this, utilizing `self.model.objects.none()` instead.