### PR TITLE
Fix change view when related object does not use 'id' field as PK

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -30,7 +30,7 @@ class ReverseInlineFormSet(BaseModelFormSet):
                  save_as_new=False):
         object = getattr(instance, self.parent_fk_name, None)
         if object:
-            qs = self.model.objects.filter(pk=object.id)
+            qs = self.model.objects.filter(pk=object.pk)
         else:
             qs = self.model.objects.none()
             self.extra = 1

--- a/tests/polls/admin.py
+++ b/tests/polls/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from polls.models import Address
 from polls.models import NonInlinePerson
 from polls.models import Person
+from polls.models import PersonWithAddressNonId
 from polls.models import PersonWithTwoAddresses
 from polls.models import PhoneNumber
 from django_reverse_admin import ReverseModelAdmin
@@ -34,6 +35,13 @@ class PersonAdmin(ReverseModelAdmin):
     ]
 
 
+class PersonWithAddressNonIdAdmin(ReverseModelAdmin):
+    list_display = ('name', 'home_addr')
+
+    inline_type = 'stacked'
+    inline_reverse = ('home_addr',)
+
+
 class PersonWithTwoAddressesAdmin(ReverseModelAdmin):
     inline_type = 'tabular'
     list_display = ('name', 'age', 'cur_addr', 'oth_addr')
@@ -57,6 +65,7 @@ class AddressAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Person, PersonAdmin)
+admin.site.register(PersonWithAddressNonId, PersonWithAddressNonIdAdmin)
 admin.site.register(PersonWithTwoAddresses, PersonWithTwoAddressesAdmin)
 admin.site.register(PhoneNumber, PhoneNumberAdmin)
 admin.site.register(NonInlinePerson, NonInlinePersonAdmin)

--- a/tests/polls/models.py
+++ b/tests/polls/models.py
@@ -15,13 +15,15 @@ class TemporalBase(models.Model):
         abstract = True
 
 
-class Address(TemporalBase):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+class AddressBase(TemporalBase):
     street = models.CharField(max_length=255)
     street_2 = models.CharField(max_length=255, blank=True, null=True)
     zipcode = models.CharField(max_length=10)
     city = models.CharField(max_length=255)
     state = models.CharField(max_length=2)
+
+    class Meta:
+        abstract = True
 
     def __str__(self):
         street_2 = ''
@@ -30,11 +32,34 @@ class Address(TemporalBase):
         return '{}{}, {}, {}'.format(self.street, street_2, self.city, self.zipcode)
 
 
+class Address(AddressBase):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+
+class AddressNonId(AddressBase):
+    address_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+
 class Person(TemporalBase):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     age = models.IntegerField(blank=True, null=True)
     home_addr = models.OneToOneField(Address,
+                                     blank=True,
+                                     null=True,
+                                     related_name='home_addr_person',
+                                     on_delete=models.CASCADE
+                                     )
+
+    def __str__(self):
+        return self.name
+
+
+class PersonWithAddressNonId(TemporalBase):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=255)
+    age = models.IntegerField(blank=True, null=True)
+    home_addr = models.OneToOneField(AddressNonId,
                                      blank=True,
                                      null=True,
                                      related_name='home_addr_person',

--- a/tests/polls/tests/test_admin.py
+++ b/tests/polls/tests/test_admin.py
@@ -4,7 +4,9 @@ from django.test import Client
 from django.urls import reverse
 
 from polls.models import Address
+from polls.models import AddressNonId
 from polls.models import Person
+from polls.models import PersonWithAddressNonId
 from polls.models import PersonWithTwoAddresses
 from polls.admin import SITE_HEADER
 import polls.tests.config as test_config
@@ -75,6 +77,20 @@ class PersonAdminTest(TestCase):
         client.post(change_url, test_config.PERSON_WITH_NO_ADDRESS)
         self.assertEquals(1, Person.objects.count())
         self.assertEquals(0, Address.objects.count())
+
+
+class PersonWithAddressNonIdAdminTest(TestCase):
+    def setUp(self):
+        User.objects.create_superuser(**test_config.ADMIN_USER)
+
+    def test_edit_person_with_address_non_id(self):
+        person = PersonWithAddressNonId.objects.create(name='Toto', home_addr=AddressNonId.objects.create())
+
+        client = Client()
+        client.login(**test_config.ADMIN_USER)
+        change_url = reverse('admin:polls_personwithaddressnonid_change', args=(person.pk,))
+        # Ensure it doesn't raise any exception.
+        client.get(change_url, test_config.PERSON_WITH_TWO_ADDRESSES)
 
 
 class PersonWithTwoAddressesAdminTest(TestCase):


### PR DESCRIPTION
First commit adds a failing test when the related object (_Address_) does not use `id` as the name of the primary key.
Second one fixes the issue in source, and so it fixes the test.

Here is the error page using the embed test site that reproduces the issue:
![django_reverse_admin pknotid](https://user-images.githubusercontent.com/21142069/71447530-b7dece80-272f-11ea-9e8d-a1b354cea8ef.png)
With the related traceback:
http://dpaste.com/2RBE2TC

Thanks for the lib, very useful piece of code ;)
My use-case at my company is exactly the one presented in the README, good job :smile: 