### PR TITLE
fixing bug in translation of title

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -316,7 +316,7 @@ class ReverseModelAdmin(ModelAdmin):
         # Inherit the default context from admin_site
         context = self.admin_site.each_context(request)
         reverse_admin_context = {
-            'title': _(('Change %s', 'Add %s')[add] % force_text(opts.verbose_name)),
+            'title': _(('Change %s', 'Add %s')[add]) % force_text(opts.verbose_name),
             'adminform': adminForm,
             # 'is_popup': '_popup' in request.REQUEST,
             'is_popup': False,


### PR DESCRIPTION
sounds when a str contains two languages for example: 'Add سلام'
ugettext does not translate it. So it is needed to first translate 'Add' or 'Change' 
and then pass it the verbose_name.

Like django:
https://github.com/django/django/blob/e2417010daf697d5a58bc2057a24b7785c4cef03/django/contrib/admin/options.py#L1604