### PR TITLE
Fix #165 support for get_readonly_fields() and get_fields() on the ReverseModelAdmin

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -225,7 +225,7 @@ class ReverseModelAdmin(ModelAdmin):
         model = self.model
         opts = model._meta
 
-        model_form = self.get_form(request)
+        model_form = self.get_form(request, object_id)
         formsets = []
 
         if add:

--- a/tests/polls/admin.py
+++ b/tests/polls/admin.py
@@ -34,6 +34,12 @@ class PersonAdmin(ReverseModelAdmin):
         }),
     ]
 
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # edit
+            return self.readonly_fields + ('insurance_number',)
+        else:
+            return self.readonly_fields
+
 
 class PersonWithAddressNonIdAdmin(ReverseModelAdmin):
     list_display = ('name', 'home_addr')

--- a/tests/polls/models.py
+++ b/tests/polls/models.py
@@ -44,6 +44,7 @@ class Person(TemporalBase):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     age = models.IntegerField(blank=True, null=True)
+    insurance_number = models.CharField(max_length=30, help_text='An example field that can only be edited at object creation time')
     home_addr = models.OneToOneField(Address,
                                      blank=True,
                                      null=True,

--- a/tests/polls/tests/config.py
+++ b/tests/polls/tests/config.py
@@ -22,6 +22,7 @@ ADMIN_USER = {
 
 PERSON_WITH_ADDRESS = {
     'name': 'Elmo',
+    'insurance_number': 'INS_1',
     'form-TOTAL_FORMS': 1,
     'form-INITIAL_FORMS': 0,
     'form-MIN_NUM_FORMS': 0,
@@ -52,6 +53,15 @@ PERSON_WITH_ADDRESS_2 = {
 
 PERSON_WITH_NO_ADDRESS = {
     'name': 'Elmo',
+    'insurance_number': 'INS_1',
+    'form-TOTAL_FORMS': 1,
+    'form-INITIAL_FORMS': 0,
+    'phonenumber_set-TOTAL_FORMS': 0,
+    'phonenumber_set-INITIAL_FORMS': 1
+}
+
+PERSON_WITH_NO_ADDRESS_2 = {
+    'name': 'Elmo (Updated)',
     'form-TOTAL_FORMS': 1,
     'form-INITIAL_FORMS': 0,
     'phonenumber_set-TOTAL_FORMS': 0,

--- a/tests/polls/tests/test_admin.py
+++ b/tests/polls/tests/test_admin.py
@@ -77,6 +77,15 @@ class PersonAdminTest(TestCase):
         client.post(change_url, test_config.PERSON_WITH_NO_ADDRESS)
         self.assertEquals(1, Person.objects.count())
         self.assertEquals(0, Address.objects.count())
+        person = Person.objects.all()[0]
+
+        # Edit the person name now
+        change_url = reverse('admin:polls_person_change', args=(person.id,))
+        client.post(change_url, test_config.PERSON_WITH_NO_ADDRESS_2)
+        self.assertEquals(1, Person.objects.count())
+        self.assertEquals(0, Address.objects.count())
+        person = Person.objects.all()[0]
+        self.assertEquals(person.name, test_config.PERSON_WITH_NO_ADDRESS_2['name'], 'but the name hasnt changed')
 
 
 class PersonWithAddressNonIdAdminTest(TestCase):


### PR DESCRIPTION
See issue #165 