### PR TITLE
Move the user-provided admin class to the beginning in bases

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -175,7 +175,7 @@ class ReverseModelAdmin(ModelAdmin):
                 if admin_class:
                     admin_class_to_use = type(
                         str('DynamicReverseInlineModelAdmin_{}'.format(admin_class.__name__)),
-                        (ReverseInlineModelAdmin, admin_class),
+                        (admin_class, ReverseInlineModelAdmin),
                         {},
                     )
                 else:


### PR DESCRIPTION
This allows the user to actually override things.

The old MRO from `bases=(ReverseInlineModelAdmin, admin_class)` was:

1. django.forms.widgets.DynamicReverseInlineModelAdmin_MyClass
2. django_reverse_admin.ReverseInlineModelAdmin
3. django.contrib.admin.options.InlineModelAdmin
4. django.contrib.admin.options.BaseModelAdmin
5. MyClass
6. object

Notably, BaseModelAdmin does not call `MyClass.__init__` because it
considers there's nothing else to call, and it sets all the typical
class-level attributes to their default empty values.

The new MRO from `bases=(admin_class, ReverseInlineModelAdmin)` is:

1. django.forms.widgets.DynamicReverseInlineModelAdmin_MyClass
2. MyClass
3. django_reverse_admin.ReverseInlineModelAdmin
4. django.contrib.admin.options.InlineModelAdmin
5. django.contrib.admin.options.BaseModelAdmin
6. object

With this position it can define its own `__init__` and override things normally.