### PR TITLE
Fix: Use gettext instead of ugettext.

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -9,7 +9,7 @@ from django.forms.formsets import all_valid
 from django.forms.models import BaseModelFormSet, modelformset_factory
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.core.exceptions import PermissionDenied, FieldDoesNotExist
 
 


### PR DESCRIPTION
This PR fixes another deprecation warning:

```
django_reverse_admin/__init__.py:322: RemovedInDjango40Warning: django.utils.translation.ugettext() is deprecated in favor of django.utils.translation.gettext().
    'title': _(('Change %s', 'Add %s')[add]) % force_str(opts.verbose_name),
```