### PR TITLE
refs #244, fix key error on read only forms

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -303,7 +303,12 @@ class ReverseModelAdmin(ModelAdmin):
                 form = model_form(instance=obj)
                 formsets, inline_instances = self._create_formsets(request, obj, change=True)
 
-        readonly_fields = self.get_readonly_fields(request, obj)
+        if not add and not self.has_change_permission(request, obj):
+            readonly_fields = flatten_fieldsets(
+                self.get_fieldsets(request, obj))
+        else:
+            readonly_fields = self.get_readonly_fields(request, obj)
+
         adminForm = helpers.AdminForm(form,
                                       list(self.get_fieldsets(request)),
                                       self.prepopulated_fields,


### PR DESCRIPTION
The read-only fields are not being set up correctly. So if you change the permissions of the Admin Model to View only then the library is raising a KeyError, since the fields can not be found in the form.